### PR TITLE
Better detection of node/browser

### DIFF
--- a/mcl.js
+++ b/mcl.js
@@ -1,13 +1,13 @@
 'use strict';
 (generator => {
-  if (typeof exports === 'object') {
-    const crypto = require('crypto')
-    crypto.getRandomValues = crypto.randomFillSync
-    generator(exports, crypto, true)
-  } else {
+  if (typeof window === 'object') {
     const crypto = window.crypto || window.msCrypto
     const exports = {}
     window.mcl = generator(exports, crypto, false)
+  } else {
+    const crypto = require('crypto')
+    crypto.getRandomValues = crypto.randomFillSync
+    generator(exports, crypto, true)
   }
 })((exports, crypto, isNodeJs) => {
   /* eslint-disable */


### PR DESCRIPTION
At https://github.com/ethereumjs/ethereumjs-vm/pull/785#issuecomment-670268717, we found that `exports` shouldn't guide the browser/node detection. It is usually present in browser builds made with Browserify, invalidating that clause.

While as ridiculous as it sounds, there isn't a certain way to know the platform for sure, but I propose at least this better heuristic, using `window` instead. The likelihood of a Node project to have a `window` global variable seems to be super low.

Additional ways to detect platforms involve: `self` and `global`. 

More on this: https://v8.dev/features/globalthis.