### PR TITLE
Move nyc from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "devDependencies": {
     "coveralls": "^3.0.1",
     "istanbul": "^0.4.5",
+    "nyc": "^11.8.0",
     "standard": "^10.0.3"
   },
   "dependencies": {
-    "nyc": "^11.8.0"
   }
 }


### PR DESCRIPTION
Hi @herumi, thanks for this great library, we are using it for the `EIP-2537` BLS precompile implementation for our [JavaScript EVM](https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/vm)! 😄 

We currently have the problem though that the `nyc` package currently being in the `dependencies` of the library is pulling in a hell lot of security vulnerabilities - some marked as `high` - when running `npm audit` on the library.

Would it be possible to merge and do a patch release on this relatively quickly? We are planning to do a new major version on the VM in two weeks and will feature-freeze at the end of next week (sorry, stumbled upon this a bit late in the process), and I'm afraid that we would otherwise have to disable the `EIP-2537` support for now for security reasons.

That would be great and super helpful! 🙂